### PR TITLE
Fix intermittent invalid OAuth state on GitHub login

### DIFF
--- a/johnverrone/src/routes/auth/github/+server.ts
+++ b/johnverrone/src/routes/auth/github/+server.ts
@@ -3,13 +3,16 @@ import { redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ cookies, url }) => {
-	const state = crypto.randomUUID();
+	// Reuse an in-flight state rather than minting a new one on every hit, so a
+	// duplicate request (double tap, mobile network retry) can't invalidate a
+	// login that's already underway by overwriting the cookie GitHub will echo back.
+	const state = cookies.get('github_oauth_state') ?? crypto.randomUUID();
 	cookies.set('github_oauth_state', state, {
 		path: '/',
 		httpOnly: true,
 		secure: true,
 		sameSite: 'lax',
-		maxAge: 600
+		maxAge: 900
 	});
 
 	// Remember where the user was headed so the callback can return them there.


### PR DESCRIPTION
Reuse an in-flight github_oauth_state cookie instead of regenerating
it on every hit to /auth/github, and extend its lifetime to 15 min.
Prevents a duplicate request (double tap, mobile network retry) from
clobbering the state that GitHub will echo back on the callback,
which was surfacing as a 400 "Invalid OAuth state" mostly on mobile.