### PR TITLE
Force HTTPS redirect before OAuth cookie logic

### DIFF
--- a/johnverrone/src/hooks.server.ts
+++ b/johnverrone/src/hooks.server.ts
@@ -1,7 +1,16 @@
-import type { Handle } from '@sveltejs/kit';
+import { redirect, type Handle } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 
 export const handle: Handle = async ({ event, resolve }) => {
+	// Force HTTPS before anything else runs. The `secure` OAuth-state cookies
+	// are silently dropped by the browser on an http:// hop (set or send), which
+	// surfaces downstream as a confusing "Invalid OAuth state" error.
+	if (!dev && event.url.protocol === 'http:') {
+		const httpsUrl = new URL(event.url);
+		httpsUrl.protocol = 'https:';
+		redirect(301, httpsUrl.toString());
+	}
+
 	if (dev) {
 		event.locals.authenticated = true;
 		event.locals.githubToken = 'dev-token';


### PR DESCRIPTION
## Summary
- The `github_oauth_state` cookie is `Secure`-only, so a browser silently drops it (won't set it or won't send it) on any hop of the OAuth flow that lands on `http://` instead of `https://`.
- On mobile this showed up as `http://johnverrone.com/auth/github/callback?...` (confirmed from the actual failing URL), which the server-side comparison then reports as `400 Invalid OAuth state` even though `code`/`state` were otherwise valid.
- `hooks.server.ts` now redirects any `http://` request to the `https://` equivalent (301, preserving path/query) before any cookie logic runs, guaranteeing the whole OAuth round trip stays on HTTPS end-to-end.

Follow-up to #167 (already merged), which fixed a separate state-cookie-clobbering race but didn't address this HTTP/HTTPS mismatch.

## Test plan
- [ ] Re-attempt admin login from a mobile device that previously hit `http://` and confirm it now upgrades to `https://` and completes login
- [ ] Confirm local dev (`bun run dev`, which serves over `http://localhost`) is unaffected, since the redirect is gated on `!dev`


---
_Generated by [Claude Code](https://claude.ai/code/session_01H1uGjSm12ZNcJSipfvNxBp)_