### PR TITLE
Map Whoop *_msk sport names to their base modality

### DIFF
--- a/johnverrone/src/lib/server/integrations/integrations.test.ts
+++ b/johnverrone/src/lib/server/integrations/integrations.test.ts
@@ -185,6 +185,8 @@ describe('whoop workouts + cross-provider dedupe', () => {
 
 	it('maps and normalizes whoop sport names', () => {
 		expect(mapWhoopSport('weightlifting')).toBe('lift');
+		expect(mapWhoopSport('weightlifting_msk')).toBe('lift');
+		expect(mapWhoopSport('Powerlifting MSK')).toBe('lift');
 		expect(mapWhoopSport('Functional Fitness')).toBe('hiit');
 		expect(mapWhoopSport('walking')).toBe('walk');
 		expect(mapWhoopSport('stroller_walking')).toBe('walk');

--- a/johnverrone/src/lib/server/integrations/whoop.ts
+++ b/johnverrone/src/lib/server/integrations/whoop.ts
@@ -102,7 +102,10 @@ const WHOOP_SPORT_TO_MODALITY: Record<string, Modality> = {
 };
 
 export function mapWhoopSport(sportName: string): Modality | null {
-	return WHOOP_SPORT_TO_MODALITY[sportName.toLowerCase().replace(/\s+/g, '_')] ?? null;
+	// Whoop reports strength sports tracked with the musculoskeletal (strength
+	// trainer) feature as e.g. "weightlifting_msk" — same sport, so map both.
+	const name = sportName.toLowerCase().replace(/\s+/g, '_').replace(/_msk$/, '');
+	return WHOOP_SPORT_TO_MODALITY[name] ?? null;
 }
 
 /**


### PR DESCRIPTION
Whoop reports strength workouts tracked with the strength trainer
(musculoskeletal) feature as e.g. "weightlifting_msk", which the
sport-to-modality table didn't recognize, so those lifts were skipped
as unmapped. Strip the _msk suffix during normalization so they map
like their base sport.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RDGphNs2JxjRhqPb1NBKXP