### PR TITLE
Map Whoop hiking-rucking to hike; silently skip golf and activity

### DIFF
--- a/johnverrone/src/lib/server/integrations/integrations.test.ts
+++ b/johnverrone/src/lib/server/integrations/integrations.test.ts
@@ -7,6 +7,7 @@ import { importStravaActivities, mapSportType, type StravaActivity } from './str
 import {
 	applyWhoopData,
 	importWhoopWorkouts,
+	isIgnoredWhoopSport,
 	mapWhoopSport,
 	whoopLocalDate,
 	type WhoopWorkout
@@ -93,11 +94,13 @@ describe('strava import', () => {
 
 		const result = await importStravaActivities(db, [
 			run(9002, '2026-09-16T18:00:00Z', { sport_type: 'Ride' }),
-			run(9003, '2026-09-16T20:00:00Z', { sport_type: 'Golf' })
+			run(9003, '2026-09-16T20:00:00Z', { sport_type: 'Pickleball' }),
+			run(9004, '2026-09-16T21:00:00Z', { sport_type: 'Golf' })
 		]);
 		expect(result.imported).toBe(0);
 		expect(result.duplicates).toBe(1);
-		expect(result.unmapped).toEqual(['Golf']);
+		// Golf is deliberately ignored, not reported as unmapped.
+		expect(result.unmapped).toEqual(['Pickleball']);
 	});
 });
 
@@ -191,7 +194,14 @@ describe('whoop workouts + cross-provider dedupe', () => {
 		expect(mapWhoopSport('walking')).toBe('walk');
 		expect(mapWhoopSport('stroller_walking')).toBe('walk');
 		expect(mapWhoopSport('hiking')).toBe('hike');
+		expect(mapWhoopSport('hiking-rucking')).toBe('hike');
+		expect(mapWhoopSport('Hiking/Rucking')).toBe('hike');
 		expect(mapWhoopSport('table tennis')).toBeNull();
+		// Deliberately ignored sports stay unmapped but are skipped silently.
+		expect(mapWhoopSport('golf')).toBeNull();
+		expect(isIgnoredWhoopSport('golf')).toBe(true);
+		expect(isIgnoredWhoopSport('activity')).toBe(true);
+		expect(isIgnoredWhoopSport('table tennis')).toBe(false);
 	});
 
 	it('imports whoop workouts, links the plan, and dedupes on re-sync', async () => {

--- a/johnverrone/src/lib/server/integrations/strava.ts
+++ b/johnverrone/src/lib/server/integrations/strava.ts
@@ -39,8 +39,15 @@ const SPORT_TO_MODALITY: Record<string, Modality> = {
 	Pilates: 'mobility'
 };
 
+// Deliberately not coached — skipped silently rather than reported as unmapped.
+const SPORT_IGNORED = new Set(['Golf']);
+
 export function mapSportType(sportType: string): Modality | null {
 	return SPORT_TO_MODALITY[sportType] ?? null;
+}
+
+export function isIgnoredSportType(sportType: string): boolean {
+	return SPORT_IGNORED.has(sportType);
 }
 
 export interface ImportResult {
@@ -70,7 +77,9 @@ export async function importStravaActivities(
 	for (const activity of activities) {
 		const modality = mapSportType(activity.sport_type);
 		if (!modality) {
-			if (!result.unmapped.includes(activity.sport_type)) result.unmapped.push(activity.sport_type);
+			if (!isIgnoredSportType(activity.sport_type) && !result.unmapped.includes(activity.sport_type)) {
+				result.unmapped.push(activity.sport_type);
+			}
 			continue;
 		}
 

--- a/johnverrone/src/lib/server/integrations/whoop.ts
+++ b/johnverrone/src/lib/server/integrations/whoop.ts
@@ -80,7 +80,7 @@ export interface WhoopImportResult {
 	workouts: ImportResult;
 }
 
-// Whoop sport names → modality. Names are normalized (lowercase, spaces→_).
+// Whoop sport names → modality. Names are normalized (lowercase, spaces/-/→_).
 const WHOOP_SPORT_TO_MODALITY: Record<string, Modality> = {
 	running: 'run',
 	trail_running: 'run',
@@ -96,16 +96,30 @@ const WHOOP_SPORT_TO_MODALITY: Record<string, Modality> = {
 	stroller_walking: 'walk',
 	hiking: 'hike',
 	rucking: 'hike',
+	hiking_rucking: 'hike',
 	yoga: 'mobility',
 	pilates: 'mobility',
 	stretching: 'mobility'
 };
 
-export function mapWhoopSport(sportName: string): Modality | null {
+// Deliberately not coached — skipped silently rather than reported as unmapped.
+const WHOOP_SPORT_IGNORED = new Set(['activity', 'golf']);
+
+function normalizeWhoopSport(sportName: string): string {
 	// Whoop reports strength sports tracked with the musculoskeletal (strength
 	// trainer) feature as e.g. "weightlifting_msk" — same sport, so map both.
-	const name = sportName.toLowerCase().replace(/\s+/g, '_').replace(/_msk$/, '');
-	return WHOOP_SPORT_TO_MODALITY[name] ?? null;
+	return sportName
+		.toLowerCase()
+		.replace(/[\s/-]+/g, '_')
+		.replace(/_msk$/, '');
+}
+
+export function mapWhoopSport(sportName: string): Modality | null {
+	return WHOOP_SPORT_TO_MODALITY[normalizeWhoopSport(sportName)] ?? null;
+}
+
+export function isIgnoredWhoopSport(sportName: string): boolean {
+	return WHOOP_SPORT_IGNORED.has(normalizeWhoopSport(sportName));
 }
 
 /**
@@ -120,7 +134,9 @@ export async function importWhoopWorkouts(db: DB, workouts: WhoopWorkout[]): Pro
 	for (const workout of workouts) {
 		const modality = mapWhoopSport(workout.sport_name);
 		if (!modality) {
-			if (!result.unmapped.includes(workout.sport_name)) result.unmapped.push(workout.sport_name);
+			if (!isIgnoredWhoopSport(workout.sport_name) && !result.unmapped.includes(workout.sport_name)) {
+				result.unmapped.push(workout.sport_name);
+			}
 			continue;
 		}
 


### PR DESCRIPTION
## Summary
- The Whoop sync was flagging `unmapped: hiking-rucking, activity, golf`. Whoop reports the combined sport name "hiking-rucking", which slipped past the sport-name normalizer (it only converted spaces to underscores), so it matched neither the existing `hiking` nor `rucking` entries. The normalizer now folds hyphens and slashes into underscores (composing with the recent `_msk` suffix handling), and `hiking_rucking` maps to the `hike` modality.
- Golf and Whoop's generic "activity" are deliberately not coached, so both the Whoop and Strava importers now have a small ignore list and skip them silently instead of nagging in the "unmapped" warning on every sync — keeping that warning meaningful for genuinely unrecognized sports.

## Test plan
- [x] `vitest run src/lib/server/integrations/integrations.test.ts` — 9/9 passing, with new cases for `hiking-rucking` / `Hiking/Rucking` mapping and the ignored-sport behavior on both importers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8r7dyXpzxgzgGpJF8DWxQ